### PR TITLE
Add GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: 'Release version (e.g., 0.1.0)'
+        required: true
+      nextVersion:
+        description: 'Next development version (e.g., 0.2.0-SNAPSHOT)'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '25'
+          distribution: 'graalvm'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            target/
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Set release version
+        run: ./mvnw -batch-mode versions:set -DnewVersion=${{ github.event.inputs.releaseVersion }} -DgenerateBackupPoms=false
+
+      - name: Build and test all modules
+        run: ./mvnw -batch-mode clean install
+
+      - name: Publish to GitHub Packages
+        id: deploy
+        run: ./mvnw -batch-mode deploy -DskipTests -s .github/settings.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit release version
+        if: success()
+        run: |
+          git add -A
+          git commit -m "Release ${{ github.event.inputs.releaseVersion }}"
+          git tag v${{ github.event.inputs.releaseVersion }}
+
+      - name: Set next development version
+        if: success()
+        run: ./mvnw -batch-mode versions:set -DnewVersion=${{ github.event.inputs.nextVersion }} -DgenerateBackupPoms=false
+
+      - name: Commit next development version
+        if: success()
+        run: |
+          git add -A
+          git commit -m "Prepare next development iteration ${{ github.event.inputs.nextVersion }}"
+
+      - name: Push changes and tags
+        if: success()
+        run: |
+          git push origin HEAD:main
+          git push origin v${{ github.event.inputs.releaseVersion }}
+
+      - name: Create GitHub Release
+        if: success()
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ github.event.inputs.releaseVersion }}
+          name: Release ${{ github.event.inputs.releaseVersion }}
+          generate_release_notes: true

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,14 @@
         </pluginRepository>
     </pluginRepositories>
 
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Hellblazer Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/Hellblazer/a-demo</url>
+        </repository>
+    </distributionManagement>
+
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
## Summary
Adds automated release workflow similar to Delos, enabling clean releases to GitHub Packages.

## Changes
- **`.github/workflows/release.yml`**: Release automation workflow
  - Triggered manually via `workflow_dispatch`
  - Takes `releaseVersion` and `nextVersion` as inputs
  - Sets release version, builds, tests, deploys to GitHub Packages
  - Creates git tag and GitHub Release
  - Bumps to next development version

- **`pom.xml`**: Added `distributionManagement` section
  - Configures GitHub Packages as deployment target
  - Points to `https://maven.pkg.github.com/Hellblazer/a-demo`

## Usage
Trigger via GitHub Actions UI or CLI:
```bash
gh workflow run release.yml -f releaseVersion=0.0.1 -f nextVersion=0.0.2-SNAPSHOT
```

## Testing
- Workflow syntax validated
- Maven deployment configuration verified