### PR TITLE
Fix release workflow GitHub Packages authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,15 +44,38 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Create Maven settings.xml with GitHub Packages credentials
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml << EOF
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+            <servers>
+              <server>
+                <id>github</id>
+                <username>github</username>
+                <password>${GITHUB_TOKEN}</password>
+              </server>
+            </servers>
+          </settings>
+          EOF
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set release version
         run: ./mvnw -batch-mode versions:set -DnewVersion=${{ github.event.inputs.releaseVersion }} -DgenerateBackupPoms=false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and test all modules
         run: ./mvnw -batch-mode clean install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to GitHub Packages
         id: deploy
-        run: ./mvnw -batch-mode deploy -DskipTests -s .github/settings.xml
+        run: ./mvnw -batch-mode deploy -DskipTests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -66,6 +89,8 @@ jobs:
       - name: Set next development version
         if: success()
         run: ./mvnw -batch-mode versions:set -DnewVersion=${{ github.event.inputs.nextVersion }} -DgenerateBackupPoms=false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit next development version
         if: success()


### PR DESCRIPTION
## Problem
Release workflow failed with:
```
[ERROR] Non-resolvable import POM: Could not transfer artifact com.hellblazer.delos:delos.app:pom:0.0.5
```

Maven couldn't resolve Delos dependencies from GitHub Packages because authentication wasn't configured.

## Solution
- Create Maven `settings.xml` with GitHub credentials **before** running any Maven commands
- Add `GITHUB_TOKEN` env var to all Maven commands:
  - `versions:set` (release version)
  - `clean install` (build/test)
  - `deploy` (publish)
  - `versions:set` (next dev version)
- Remove redundant `-s .github/settings.xml` flag from deploy (now uses `~/.m2/settings.xml`)

## Testing
Will retry release after this fix is merged.